### PR TITLE
feat: handle api gateway v2 cookies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "afterEach": false
   },
   "rules": {
-    "array-bracket-spacing": 0
+    "array-bracket-spacing": 0,
+    "dot-notation": 0
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: ci
+
+on:
+  push:
+    paths-ignore:
+      - "*.md"
+  pull_request:
+    paths-ignore:
+      - "*.md"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12, 14, 16]
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Use Node.js
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: |
+          npm install
+      - name: Run tests
+        run: |
+          npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 package-lock.json
 .nyc_output
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ module.exports = (app, options) => (event, context, callback) => {
     headers['x-request-id'] = headers['x-request-id'] || event.requestContext.requestId
   }
 
+  // API gateway v2 cookies
+  if (event.cookies && event.cookies.length) {
+    headers['cookie'] = event.cookies.join(';')
+  }
+
   const prom = new Promise((resolve) => {
     app.inject({ method, url, query, payload, headers }, (err, res) => {
       if (err) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -5,12 +5,13 @@ const fs = require('fs')
 const awsLambdaFastify = require('../index')
 
 test('GET', async (t) => {
-  t.plan(14)
+  t.plan(15)
 
   const app = fastify()
   app.get('/test', async (request, reply) => {
     t.equal(request.headers['x-my-header'], 'wuuusaaa')
-    t.equal(request.headers['x-apigateway-event'], '%7B%22httpMethod%22%3A%22GET%22%2C%22path%22%3A%22%2Ftest%22%2C%22headers%22%3A%7B%22X-My-Header%22%3A%22wuuusaaa%22%7D%2C%22queryStringParameters%22%3A%22%22%7D')
+    t.equal(request.headers['cookie'], 'foo=bar')
+    t.equal(request.headers['x-apigateway-event'], '%7B%22httpMethod%22%3A%22GET%22%2C%22path%22%3A%22%2Ftest%22%2C%22headers%22%3A%7B%22X-My-Header%22%3A%22wuuusaaa%22%7D%2C%22cookies%22%3A%5B%22foo%3Dbar%22%5D%2C%22queryStringParameters%22%3A%22%22%7D')
     t.equal(request.headers['user-agent'], 'lightMyRequest')
     t.equal(request.headers.host, 'localhost:80')
     t.equal(request.headers['content-length'], '0')
@@ -25,6 +26,7 @@ test('GET', async (t) => {
     headers: {
       'X-My-Header': 'wuuusaaa'
     },
+    cookies: ['foo=bar'],
     queryStringParameters: ''
   })
   t.equal(ret.statusCode, 200)


### PR DESCRIPTION
fixes: https://github.com/fastify/aws-lambda-fastify/issues/50

Also test in production environment with this typescript snippet:
```ts
import awsLambdaFastify from 'aws-lambda-fastify';
import app from './app';

const proxy = awsLambdaFastify(app);
const f = function (event, context, callback) {
  if (event.cookies && event.cookies.length) {
    event.headers['cookie'] = event.cookies.join(';');
  }
  return proxy(event, context, callback);
};
module.exports.handler = f;
```

Sidenote:
- Added github actions ci
- Added "dot-notation": 0 in eslint otherwise the code style won't be respected
- Added yarn.lock in gitignore for yarn users
- @mcollina it seems like github actions are not activated on this repo. Could you check in the settings?