### PR TITLE
feat: use fast-json-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "fastify": "^3.17.0",
     "serverless-http": "^2.7.0",
     "tap": "^15.0.9"
+  },
+  "dependencies": {
+    "fast-json-stringify": "^2.7.6"
   }
 }

--- a/performanceTest/test.js
+++ b/performanceTest/test.js
@@ -3,6 +3,7 @@ const suite = new Benchmark.Suite()
 
 const fastify = require('fastify')
 const event = {
+  version: '1.0',
   httpMethod: 'GET',
   path: '/test',
   headers: {},

--- a/stringifiers.js
+++ b/stringifiers.js
@@ -1,0 +1,248 @@
+const fastJson = require('fast-json-stringify')
+
+const v1 = fastJson({
+  type: 'object',
+  properties: {
+    version: { type: 'string' },
+    resource: { type: 'string' },
+    path: { type: 'string' },
+    httpMethod: { type: 'string' },
+    headers: {
+      type: 'object',
+      patternProperties: {
+        '.*': { type: 'string' }
+      }
+    },
+    multiValueHeaders: {
+      type: 'object',
+      patternProperties: {
+        '.*': { type: 'array', items: { type: 'string' } }
+      }
+    },
+    queryStringParameters: {
+      type: 'object',
+      patternProperties: {
+        '.*': { type: 'string' }
+      }
+    },
+    multiValueQueryStringParameters: {
+      type: 'object',
+      patternProperties: {
+        '.*': { type: 'array', items: { type: 'string' } }
+      }
+    },
+    requestContext: {
+      accountId: { type: 'string' },
+      apiId: { type: 'string' },
+      authorizer: {
+        type: 'object',
+        properties: {
+          claims: {
+            oneOf: [
+              {
+                type: 'object',
+                patternProperties: {
+                  '.*': { type: 'string' }
+                }
+              },
+              { type: 'null' }
+            ]
+          },
+          scopes: {
+            oneOf: [
+              {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              },
+              { type: 'null' }
+            ]
+          }
+        }
+      },
+      domainName: { type: 'string' },
+      domainPrefix: { type: 'string' },
+      extendedRequestId: { type: 'string' },
+      httpMethod: { type: 'string' },
+      identity: {
+        type: 'object',
+        properties: {
+          accessKey: { type: 'string' },
+          accountId: { type: 'string' },
+          caller: { type: 'string' },
+          cognitoAuthenticationProvider: { type: 'string' },
+          cognitoAuthenticationType: { type: 'string' },
+          cognitoIdentityId: { type: 'string' },
+          cognitoIdentityPoolId: { type: 'string' },
+          principalOrgId: { type: 'string' },
+          sourceIp: { type: 'string' },
+          user: { type: 'string' },
+          userAgent: { type: 'string' },
+          userArn: { type: 'string' },
+          clientCert: {
+            type: 'object',
+            properties: {
+              clientCertPem: { type: 'string' },
+              subjectDN: { type: 'string' },
+              issuerDN: { type: 'string' },
+              serialNumber: { type: 'string' },
+              validity: {
+                type: 'object',
+                properties: {
+                  notBefore: { type: 'string' },
+                  notAfter: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      },
+      path: { type: 'string' },
+      protocol: { type: 'string' },
+      requestTime: { type: 'string' },
+      requestTimeEpoch: { type: 'number' },
+      resourceId: { type: 'string' },
+      resourcePath: { type: 'string' },
+      stage: { type: 'string' }
+    },
+    pathParameters: {
+      oneOf: [
+        {
+          type: 'object',
+          patternProperties: {
+            '.*': { type: 'string' }
+          }
+        },
+        { type: 'null' }
+      ]
+    },
+    stageVariables: {
+      oneOf: [
+        {
+          type: 'object',
+          patternProperties: {
+            '.*': { type: 'string' }
+          }
+        },
+        { type: 'null' }
+      ]
+    },
+    body: { type: 'string' },
+    isBase64Encoded: { type: 'boolean' }
+  }
+})
+
+const v2 = fastJson({
+  type: 'object',
+  properties: {
+    version: { type: 'string' },
+    routeKey: { type: 'string' },
+    rawPath: { type: 'string' },
+    rawQueryString: { type: 'string' },
+    cookies: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    },
+    headers: {
+      type: 'object',
+      patternProperties: {
+        '.*': { type: 'string' }
+      }
+    },
+    queryStringParameters: {
+      type: 'object',
+      patternProperties: {
+        '.*': { type: 'string' }
+      }
+    },
+    requestContext: {
+      type: 'object',
+      properties: {
+        accountId: { type: 'string' },
+        apiId: { type: 'string' },
+        authentication: {
+          type: 'object',
+          properties: {
+            clientCert: {
+              type: 'object',
+              properties: {
+                clientCertPem: { type: 'string' },
+                subjectDN: { type: 'string' },
+                issuerDN: { type: 'string' },
+                serialNumber: { type: 'string' },
+                validity: {
+                  type: 'object',
+                  properties: {
+                    notBefore: { type: 'string' },
+                    notAfter: { type: 'string' }
+                  }
+                }
+              }
+            }
+          }
+        },
+        authorizer: {
+          type: 'object',
+          properties: {
+            jwt: {
+              type: 'object',
+              properties: {
+                claims: {
+                  type: 'object',
+                  patternProperties: {
+                    '.*': { type: 'string' }
+                  }
+                },
+                scopes: {
+                  type: 'array',
+                  items: {
+                    type: 'string'
+                  }
+                }
+              }
+            }
+          }
+        },
+        domainName: { type: 'string' },
+        domainPrefix: { type: 'string' },
+        http: {
+          type: 'object',
+          properties: {
+            method: { type: 'string' },
+            path: { type: 'string' },
+            protocol: { type: 'string' },
+            sourceIp: { type: 'string' },
+            userAgent: { type: 'string' }
+          }
+        },
+        requestId: { type: 'string' },
+        routeKey: { type: 'string' },
+        stage: { type: 'string' },
+        time: { type: 'string' },
+        timeEpoch: { type: 'number' }
+      }
+    },
+    body: { type: 'string' },
+    pathParameters: {
+      type: 'object',
+      patternProperties: {
+        '.*': { type: 'string' }
+      }
+    },
+    isBase64Encoded: { type: 'boolean' },
+    stageVariables: {
+      type: 'object',
+      patternProperties: {
+        '.*': { type: 'string' }
+      }
+    }
+  }
+})
+
+module.exports = {
+  '1.0': v1,
+  '2.0': v2
+}

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -11,7 +11,7 @@ test('GET', async (t) => {
   app.get('/test', async (request, reply) => {
     t.equal(request.headers['x-my-header'], 'wuuusaaa')
     t.equal(request.headers['cookie'], 'foo=bar')
-    t.equal(request.headers['x-apigateway-event'], '%7B%22httpMethod%22%3A%22GET%22%2C%22path%22%3A%22%2Ftest%22%2C%22headers%22%3A%7B%22X-My-Header%22%3A%22wuuusaaa%22%7D%2C%22cookies%22%3A%5B%22foo%3Dbar%22%5D%2C%22queryStringParameters%22%3A%22%22%7D')
+    t.equal(request.headers['x-apigateway-event'], '%7B%22version%22%3A%222.0%22%2C%22cookies%22%3A%5B%22foo%3Dbar%22%5D%2C%22headers%22%3A%7B%22X-My-Header%22%3A%22wuuusaaa%22%7D%2C%22queryStringParameters%22%3A%7B%7D%7D')
     t.equal(request.headers['user-agent'], 'lightMyRequest')
     t.equal(request.headers.host, 'localhost:80')
     t.equal(request.headers['content-length'], '0')
@@ -21,6 +21,7 @@ test('GET', async (t) => {
   })
   const proxy = awsLambdaFastify(app)
   const ret = await proxy({
+    version: '2.0',
     httpMethod: 'GET',
     path: '/test',
     headers: {
@@ -48,7 +49,7 @@ test('GET with base64 encoding response', async (t) => {
   const app = fastify()
   app.get('/test', async (request, reply) => {
     t.equal(request.headers['x-my-header'], 'wuuusaaa')
-    t.equal(request.headers['x-apigateway-event'], '%7B%22httpMethod%22%3A%22GET%22%2C%22path%22%3A%22%2Ftest%22%2C%22headers%22%3A%7B%22X-My-Header%22%3A%22wuuusaaa%22%2C%22Content-Type%22%3A%22application%2Fjson%22%7D%7D')
+    t.equal(request.headers['x-apigateway-event'], '%7B%22version%22%3A%221.0%22%2C%22path%22%3A%22%2Ftest%22%2C%22httpMethod%22%3A%22GET%22%2C%22headers%22%3A%7B%22X-My-Header%22%3A%22wuuusaaa%22%2C%22Content-Type%22%3A%22application%2Fjson%22%7D%7D')
     t.equal(request.headers['user-agent'], 'lightMyRequest')
     t.equal(request.headers.host, 'localhost:80')
     t.equal(request.headers['content-length'], '0')
@@ -58,6 +59,7 @@ test('GET with base64 encoding response', async (t) => {
   })
   const proxy = awsLambdaFastify(app, { binaryMimeTypes: ['application/octet-stream'] })
   const ret = await proxy({
+    version: '1.0',
     httpMethod: 'GET',
     path: '/test',
     headers: {

--- a/test/stringifiers.test.js
+++ b/test/stringifiers.test.js
@@ -1,0 +1,147 @@
+const { test } = require('tap')
+const stringifiers = require('../stringifiers')
+
+const payloadV1 = {
+  version: '1.0',
+  resource: '/my/path',
+  path: '/my/path',
+  httpMethod: 'GET',
+  headers: {
+    header1: 'value1',
+    header2: 'value2'
+  },
+  multiValueHeaders: {
+    header1: ['value1'],
+    header2: ['value1', 'value2']
+  },
+  queryStringParameters: {
+    parameter1: 'value1',
+    parameter2: 'value'
+  },
+  multiValueQueryStringParameters: {
+    parameter1: ['value1', 'value2'],
+    parameter2: ['value']
+  },
+  requestContext: {
+    accountId: '123456789012',
+    apiId: 'id',
+    authorizer: {
+      claims: null,
+      scopes: null
+    },
+    domainName: 'id.execute-api.us-east-1.amazonaws.com',
+    domainPrefix: 'id',
+    extendedRequestId: 'request-id',
+    httpMethod: 'GET',
+    identity: {
+      accessKey: null,
+      accountId: null,
+      caller: null,
+      cognitoAuthenticationProvider: null,
+      cognitoAuthenticationType: null,
+      cognitoIdentityId: null,
+      cognitoIdentityPoolId: null,
+      principalOrgId: null,
+      sourceIp: 'IP',
+      user: null,
+      userAgent: 'user-agent',
+      userArn: null,
+      clientCert: {
+        clientCertPem: 'CERT_CONTENT',
+        subjectDN: 'www.example.com',
+        issuerDN: 'Example issuer',
+        serialNumber: 'a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1',
+        validity: {
+          notBefore: 'May 28 12:30:02 2019 GMT',
+          notAfter: 'Aug  5 09:36:04 2021 GMT'
+        }
+      }
+    },
+    path: '/my/path',
+    protocol: 'HTTP/1.1',
+    requestId: 'id=',
+    requestTime: '04/Mar/2020:19:15:17 +0000',
+    requestTimeEpoch: 1583349317135,
+    resourceId: null,
+    resourcePath: '/my/path',
+    stage: '$default'
+  },
+  pathParameters: null,
+  stageVariables: null,
+  body: 'Hello from Lambda!',
+  isBase64Encoded: false
+}
+
+const payloadV2 = {
+  version: '2.0',
+  routeKey: '$default',
+  rawPath: '/my/path',
+  rawQueryString: 'parameter1=value1&parameter1=value2&parameter2=value',
+  cookies: ['cookie1', 'cookie2'],
+  headers: {
+    header1: 'value1',
+    header2: 'value1,value2'
+  },
+  queryStringParameters: {
+    parameter1: 'value1,value2',
+    parameter2: 'value'
+  },
+  requestContext: {
+    accountId: '123456789012',
+    apiId: 'api-id',
+    authentication: {
+      clientCert: {
+        clientCertPem: 'CERT_CONTENT',
+        subjectDN: 'www.example.com',
+        issuerDN: 'Example issuer',
+        serialNumber: 'a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1',
+        validity: {
+          notBefore: 'May 28 12:30:02 2019 GMT',
+          notAfter: 'Aug  5 09:36:04 2021 GMT'
+        }
+      }
+    },
+    authorizer: {
+      jwt: {
+        claims: {
+          claim1: 'value1',
+          claim2: 'value2'
+        },
+        scopes: ['scope1', 'scope2']
+      }
+    },
+    domainName: 'id.execute-api.us-east-1.amazonaws.com',
+    domainPrefix: 'id',
+    http: {
+      method: 'POST',
+      path: '/my/path',
+      protocol: 'HTTP/1.1',
+      sourceIp: 'IP',
+      userAgent: 'agent'
+    },
+    requestId: 'id',
+    routeKey: '$default',
+    stage: '$default',
+    time: '12/Mar/2020:19:03:58 +0000',
+    timeEpoch: 1583348638390
+  },
+  body: 'Hello from Lambda',
+  pathParameters: {
+    parameter1: 'value1'
+  },
+  isBase64Encoded: false,
+  stageVariables: {
+    stageVariable1: 'value1',
+    stageVariable2: 'value2'
+  }
+}
+
+test('Serializer v1', (t) => {
+  t.plan(1)
+  t.equal(stringifiers['1.0'](payloadV1), JSON.stringify(payloadV1))
+})
+
+test('Serializer v2', (t) => {
+  t.plan(1)
+  t.equal(stringifiers['2.0'](payloadV2), JSON.stringify(payloadV2))
+})


### PR DESCRIPTION
Aims to fix: https://github.com/fastify/aws-lambda-fastify/issues/54

After few tests i remarked a slight improvement in terms of performances. See:

Benchmarks:
```
// master
aws-lambda-fastify x 20,154 ops/sec ±9.73% (70 runs sampled)
aws-serverless-express x 2,811 ops/sec ±7.62% (68 runs sampled)
aws-serverless-fastify x 4,034 ops/sec ±3.28% (69 runs sampled)
serverless-http x 18,123 ops/sec ±5.17% (75 runs sampled)
```
```
// this branch
aws-lambda-fastify x 22,178 ops/sec ±9.67% (74 runs sampled)
aws-serverless-express x 3,061 ops/sec ±6.93% (64 runs sampled)
aws-serverless-fastify x 4,241 ops/sec ±2.49% (71 runs sampled)
serverless-http x 17,973 ops/sec ±5.43% (70 runs sampled)
```

On the other hand the event in the bench test is really small. If we use a big event like the provided v1 for example we have those results:
```
//main
aws-lambda-fastify x 14,636 ops/sec ±5.78% (72 runs sampled)
aws-serverless-express x 2,627 ops/sec ±6.22% (66 runs sampled)
aws-serverless-fastify x 3,924 ops/sec ±3.07% (69 runs sampled)
serverless-http x 15,178 ops/sec ±6.32% (70 runs sampled)
```
```
// branch
aws-lambda-fastify x 12,288 ops/sec ±7.07% (74 runs sampled)
aws-serverless-express x 2,724 ops/sec ±5.06% (65 runs sampled)
aws-serverless-fastify x 3,968 ops/sec ±2.35% (71 runs sampled)
serverless-http x 15,264 ops/sec ±5.01% (73 runs sampled)
```

So in the end i think this is not worth the shot, plus we add dependency and potential issues with the schema. Sending this PR for documentation/discussion.