### PR TITLE
feat: update tests

### DIFF
--- a/performanceTest/test.js
+++ b/performanceTest/test.js
@@ -42,6 +42,10 @@ suite
     proxy(event, {}, () => deferred.resolve())
   }, { defer: true })
 
+  .add('aws-lambda-fastify (serializeLambdaArguments : false)', (deferred) => {
+    proxy(event, { serializeLambdaArguments: false }, () => deferred.resolve())
+  }, { defer: true })
+
   .add('aws-serverless-express', (deferred) => {
     appAwsServerlessExpress.ready(() => {
       awsServerlessExpress.proxy(server, event, {}, 'CALLBACK', () => deferred.resolve())


### PR DESCRIPTION
As the new option `serializeLambdaArguments` as landed i think it could be nice to update performance tests and also the README for it.
For example on my machine:
```
aws-lambda-fastify x 22,734 ops/sec ±6.26% (75 runs sampled)
aws-lambda-fastify no serialize event x 24,646 ops/sec ±2.58% (76 runs sampled)
aws-serverless-express x 3,207 ops/sec ±6.83% (60 runs sampled)
aws-serverless-fastify x 3,613 ops/sec ±3.59% (66 runs sampled)
serverless-http x 15,661 ops/sec ±10.71% (67 runs sampled)
```

@adrai i don't know the machine you were using for your benchmarks. Feel free to provide your benchs to update the Readme.