### PR TITLE
feat: Add TypeScript definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Inspired by the AWSLABS [aws-serverless-express](https://github.com/awslabs/aws-
 $ npm install aws-lambda-fastify
 ```
 
+## Options
+
+**aws-lambda-fastify** can take options by passing them with : `awsLambdaFastify(app, options)`
+
+| property                       | description                                                                                                                          | default value |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| binaryMimeTypes                | Array of binary MimeTypes to handle                                                                                                  | `[]`          |
+| serializeLambdaArguments       | Activate the serialization of lambda Event and Context in http header `x-apigateway-event` `x-apigateway-context`                    | `true`        |
+| callbackWaitsForEmptyEventLoop | See: [Official Documentation](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html#nodejs-prog-model-context-properties) | `undefined`   |
+
 ## 📖Example
 
 ### lambda.js

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+import { Context } from "aws-lambda";
+import { FastifyInstance } from "fastify";
+
+export interface LambdaFastifyOptions {
+  binaryMimeTypes?: string[];
+  callbackWaitsForEmptyEventLoop?: boolean;
+  serializeLambdaArguments?: boolean;
+}
+
+export type PromiseHandler<TEvent = any, TResult = any> = (
+  event: TEvent,
+  context: Context
+) => Promise<TResult>;
+
+export default function awsLambdaFastify<TEvent, TResult>(
+  app: FastifyInstance,
+  options?: LambdaFastifyOptions
+): PromiseHandler<TEvent, TResult>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,12 +7,30 @@ export interface LambdaFastifyOptions {
   serializeLambdaArguments?: boolean;
 }
 
-export type PromiseHandler<TEvent = any, TResult = any> = (
+export interface LambdaResponse {
+  statusCode: number;
+  body: string;
+  headers: Record<string, string>;
+  isBase64Encoded: boolean;
+}
+
+export type PromiseHandler<TEvent = any, TResult = LambdaResponse> = (
   event: TEvent,
   context: Context
 ) => Promise<TResult>;
 
-export default function awsLambdaFastify<TEvent, TResult>(
+export type CallbackHandler<TEvent = any, TResult = LambdaResponse> = (
+  event: TEvent,
+  context: Context,
+  callback: (err?: Error, result?: TResult) => void
+) => void;
+
+export default function awsLambdaFastify<TEvent, TResult = LambdaResponse>(
   app: FastifyInstance,
   options?: LambdaFastifyOptions
 ): PromiseHandler<TEvent, TResult>;
+
+export default function awsLambdaFastify<TEvent, TResult = LambdaResponse>(
+  app: FastifyInstance,
+  options?: LambdaFastifyOptions
+): CallbackHandler<TEvent, TResult>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import fastify, { FastifyInstance } from "fastify";
+import fastify from "fastify";
 import awsLambdaFastify, { PromiseHandler, LambdaFastifyOptions } from ".";
 import { expectType, expectError, expectAssignable } from "tsd";
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,25 @@
+import fastify, { FastifyInstance } from "fastify";
+import awsLambdaFastify, { PromiseHandler, LambdaFastifyOptions } from ".";
+import { expectType, expectError, expectAssignable } from "tsd";
+
+const app = fastify();
+
+expectType<PromiseHandler<unknown, unknown>>(awsLambdaFastify(app));
+expectType<PromiseHandler<unknown, unknown>>(awsLambdaFastify(app, {}));
+expectAssignable<LambdaFastifyOptions>({ binaryMimeTypes: ["foo", "bar"] });
+expectAssignable<LambdaFastifyOptions>({
+  callbackWaitsForEmptyEventLoop: true,
+});
+expectAssignable<LambdaFastifyOptions>({
+  serializeLambdaArguments: true,
+});
+expectAssignable<LambdaFastifyOptions>({
+  binaryMimeTypes: ["foo", "bar"],
+  callbackWaitsForEmptyEventLoop: true,
+  serializeLambdaArguments: true,
+});
+expectType<PromiseHandler<unknown, boolean>>(
+  awsLambdaFastify<unknown, boolean>(app)
+);
+expectError(awsLambdaFastify());
+expectError(awsLambdaFastify(app, { neh: "definition" }));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,11 +1,50 @@
 import fastify from "fastify";
-import awsLambdaFastify, { PromiseHandler, LambdaFastifyOptions } from ".";
+import awsLambdaFastify, {
+  PromiseHandler,
+  CallbackHandler,
+  LambdaFastifyOptions,
+  LambdaResponse,
+} from ".";
+
 import { expectType, expectError, expectAssignable } from "tsd";
 
 const app = fastify();
 
-expectType<PromiseHandler<unknown, unknown>>(awsLambdaFastify(app));
-expectType<PromiseHandler<unknown, unknown>>(awsLambdaFastify(app, {}));
+const lambdaCtx = {
+  callbackWaitsForEmptyEventLoop: false,
+  functionName: "func",
+  functionVersion: "2",
+  invokedFunctionArn: "arn",
+  memoryLimitInMB: "666",
+  awsRequestId: "1337",
+  logGroupName: "Log",
+  logStreamName: "stream",
+  getRemainingTimeInMillis: () => 1,
+  done: () => {},
+  fail: () => {},
+  succeed: () => {},
+};
+
+// Callback handler
+const proxyCallback: CallbackHandler<unknown, unknown> = awsLambdaFastify(app);
+expectType<void>(proxyCallback({}, lambdaCtx, (err, res) => {}));
+
+// Promise handler
+
+// Generic type passed
+const proxyPromise: PromiseHandler<unknown, Record<string, string>> =
+  awsLambdaFastify(app);
+expectType<PromiseHandler<unknown>>(awsLambdaFastify(app));
+expectType<Promise<Record<string, string>>>(proxyPromise({}, lambdaCtx));
+expectType<PromiseHandler<unknown, LambdaResponse>>(awsLambdaFastify(app, {}));
+expectType<PromiseHandler<unknown, boolean>>(
+  awsLambdaFastify<unknown, boolean>(app)
+);
+
+// Default type
+const proxyDefault = awsLambdaFastify(app);
+expectType<Promise<LambdaResponse>>(proxyDefault({}, lambdaCtx));
+
 expectAssignable<LambdaFastifyOptions>({ binaryMimeTypes: ["foo", "bar"] });
 expectAssignable<LambdaFastifyOptions>({
   callbackWaitsForEmptyEventLoop: true,
@@ -18,8 +57,11 @@ expectAssignable<LambdaFastifyOptions>({
   callbackWaitsForEmptyEventLoop: true,
   serializeLambdaArguments: true,
 });
-expectType<PromiseHandler<unknown, boolean>>(
-  awsLambdaFastify<unknown, boolean>(app)
-);
+expectAssignable<LambdaFastifyOptions>({
+  binaryMimeTypes: ["foo", "bar"],
+  callbackWaitsForEmptyEventLoop: true,
+  serializeLambdaArguments: true,
+});
+
 expectError(awsLambdaFastify());
 expectError(awsLambdaFastify(app, { neh: "definition" }));

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "npm run lint && tap -J -R specy --no-coverage test/*test.js",
+    "test": "npm run lint && tap -J -R specy --no-coverage test/*test.js && npm run test:typescript",
+    "test:typescript": "tsd",
     "performance": "npm run lint && node performanceTest/test"
   },
   "devDependencies": {
+    "aws-lambda": "^1.0.6",
     "aws-serverless-express": "^3.4.0",
     "aws-serverless-fastify": "^1.0.26",
     "benchmark": "^2.1.4",
@@ -45,6 +47,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "fastify": "^3.17.0",
     "serverless-http": "^2.7.0",
-    "tap": "^15.0.9"
+    "tap": "^15.0.9",
+    "tsd": "^0.17.0"
   }
 }


### PR DESCRIPTION
Following https://github.com/fastify/aws-lambda-fastify/pull/49 adding the typescript definition and tests.

Also updated the doc to document the options.