### PR TITLE
fix: decode query when triggered by alb

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,20 @@ module.exports = (app, options) => {
         event.requestContext.resourcePath.indexOf(`/${event.requestContext.stage}/`) !== 0) {
       url = url.substring(event.requestContext.stage.length + 1)
     }
-    const query = event.multiValueQueryStringParameters || event.queryStringParameters || {}
+    const query = {}
+    if (event.requestContext && event.requestContext.elb) {
+      if (event.multiValueQueryStringParameters) {
+        Object.keys(event.multiValueQueryStringParameters).forEach((q) => {
+          query[decodeURIComponent(q)] = event.multiValueQueryStringParameters[q].map((val) => decodeURIComponent(val))
+        })
+      } else if (event.queryStringParameters) {
+        Object.keys(event.queryStringParameters).forEach((q) => {
+          query[decodeURIComponent(q)] = decodeURIComponent(event.queryStringParameters[q])
+        })
+      }
+    } else {
+      Object.assign(query, event.multiValueQueryStringParameters || event.queryStringParameters)
+    }
     const headers = Object.assign({}, event.headers)
     if (event.multiValueHeaders) {
       Object.keys(event.multiValueHeaders).forEach((h) => {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -101,6 +101,29 @@ test('GET with multi-value query params', async (t) => {
   t.equal(ret.body, '{"foo":["qux","bar"]}')
 })
 
+test('GET with double encoded query value', async (t) => {
+  t.plan(2)
+
+  const app = fastify()
+  app.get('/test', async (request, reply) => {
+    reply.send(request.query)
+  })
+  const proxy = awsLambdaFastify(app)
+
+  const ret = await proxy({
+    httpMethod: 'GET',
+    path: '/test',
+    queryStringParameters: {
+      foo: 'foo%3Fbar'
+    },
+    multiValueQueryStringParameters: {
+      foo: ['foo%40bar', 'foo%3Fbar']
+    }
+  })
+  t.equal(ret.statusCode, 200)
+  t.equal(ret.body, '{"foo":["foo%40bar","foo%3Fbar"]}')
+})
+
 test('POST', async (t) => {
   t.plan(17)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #90

This should probably be considered a breaking change, since anyone using this library with an ALB might be wrapping the handler and decoding the query themselves.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
