### PR TITLE
Rename Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-lambda-fastify",
+  "name": "@fastify/aws-lambda",
   "description": "Inspired by aws-serverless-express to work with Fastify with inject functionality.",
   "keywords": [
     "aws",
@@ -26,7 +26,7 @@
     "url": "https://github.com/fastify/aws-lambda-fastify/issues"
   },
   "license": "MIT",
-  "version": "2.1.6",
+  "version": "3.0.0",
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
@@ -55,5 +55,8 @@
     "aws-serverless-fastify": {
       "fastify": "^4.0.0-rc.3"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This pull request renames the module according to the discussion in
https://github.com/fastify/fastify/issues/3733.

Note that the deprecation module has already been published and that the
code for it does not exist in this repository. The code for the published
deprecation module was generated by https://github.com/fastify/deprecate-modules
and run on @RafaelGSS local system.

Coordinating the drastic changes to the code for the module deprecation and
then restoring the code for the module renaming would have been extremely
difficult and prohibitively tedious.

**Important: no further releases should be added to the old major version.**