### PR TITLE
Base64-encode content if content-encoding indicates that content is compressed, add enforceBase64 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm i @fastify/aws-lambda
 | property                       | description                                                                                                                          | default value |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
 | binaryMimeTypes                | Array of binary MimeTypes to handle                                                                                                  | `[]`          |
-| isBinary                       | Function that receives the response and returns a boolean indicating if the response content is binary or not | `undefined` |
+| isBase64Encoded                | Function that receives the reply and returns a boolean indicating if the response content is binary or not                           | `undefined`   |
 | serializeLambdaArguments       | Activate the serialization of lambda Event and Context in http header `x-apigateway-event` `x-apigateway-context`                    | `false` *(was `true` for <v2.0.0)*        |
 | decorateRequest       | Decorates the fastify request with the lambda Event and Context `request.awsLambda.event` `request.awsLambda.context`                    | `true`        |
 | decorationPropertyName       | The default property name for request decoration                    | `awsLambda`        |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ npm i @fastify/aws-lambda
 | decorateRequest       | Decorates the fastify request with the lambda Event and Context `request.awsLambda.event` `request.awsLambda.context`                    | `true`        |
 | decorationPropertyName       | The default property name for request decoration                    | `awsLambda`        |
 | callbackWaitsForEmptyEventLoop | See: [Official Documentation](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html#nodejs-prog-model-context-properties) | `undefined`   |
+| isBinary                       | Function that receives the response and returns a boolean indicating if the response content is binary or not | `undefined` |
 
 ## 📖Example
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ $ npm i @fastify/aws-lambda
 | property                       | description                                                                                                                          | default value |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
 | binaryMimeTypes                | Array of binary MimeTypes to handle                                                                                                  | `[]`          |
+| isBinary                       | Function that receives the response and returns a boolean indicating if the response content is binary or not | `undefined` |
 | serializeLambdaArguments       | Activate the serialization of lambda Event and Context in http header `x-apigateway-event` `x-apigateway-context`                    | `false` *(was `true` for <v2.0.0)*        |
 | decorateRequest       | Decorates the fastify request with the lambda Event and Context `request.awsLambda.event` `request.awsLambda.context`                    | `true`        |
 | decorationPropertyName       | The default property name for request decoration                    | `awsLambda`        |
 | callbackWaitsForEmptyEventLoop | See: [Official Documentation](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html#nodejs-prog-model-context-properties) | `undefined`   |
-| isBinary                       | Function that receives the response and returns a boolean indicating if the response content is binary or not | `undefined` |
 
 ## 📖Example
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm i @fastify/aws-lambda
 | property                       | description                                                                                                                          | default value |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
 | binaryMimeTypes                | Array of binary MimeTypes to handle                                                                                                  | `[]`          |
-| isBase64Encoded                | Function that receives the reply and returns a boolean indicating if the response content is binary or not                           | `undefined`   |
+| enforceBase64                  | Function that receives the reply and returns a boolean indicating if the response content is binary or not                           | `undefined`   |
 | serializeLambdaArguments       | Activate the serialization of lambda Event and Context in http header `x-apigateway-event` `x-apigateway-context`                    | `false` *(was `true` for <v2.0.0)*        |
 | decorateRequest       | Decorates the fastify request with the lambda Event and Context `request.awsLambda.event` `request.awsLambda.context`                    | `true`        |
 | decorationPropertyName       | The default property name for request decoration                    | `awsLambda`        |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm i @fastify/aws-lambda
 | property                       | description                                                                                                                          | default value |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
 | binaryMimeTypes                | Array of binary MimeTypes to handle                                                                                                  | `[]`          |
-| enforceBase64                  | Function that receives the reply and returns a boolean indicating if the response content is binary or not                           | `undefined`   |
+| enforceBase64                  | Function that receives the reply and returns a boolean indicating if the response content is binary or not and should be base64-encoded                          | `undefined`   |
 | serializeLambdaArguments       | Activate the serialization of lambda Event and Context in http header `x-apigateway-event` `x-apigateway-context`                    | `false` *(was `true` for <v2.0.0)*        |
 | decorateRequest       | Decorates the fastify request with the lambda Event and Context `request.awsLambda.event` `request.awsLambda.context`                    | `true`        |
 | decorationPropertyName       | The default property name for request decoration                    | `awsLambda`        |

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export interface LambdaFastifyOptions {
   serializeLambdaArguments?: boolean;
   decorateRequest?: boolean;
   decorationPropertyName?: string;
-  isBinary?: (reply: FastifyReply) => boolean;
+  enforceBase64?: (reply: FastifyReply) => boolean;
 }
 
 export interface LambdaResponse {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Context } from "aws-lambda";
-import { FastifyInstance } from "fastify";
+import { FastifyInstance, FastifyReply } from "fastify";
 
 export interface LambdaFastifyOptions {
   binaryMimeTypes?: string[];
@@ -7,6 +7,7 @@ export interface LambdaFastifyOptions {
   serializeLambdaArguments?: boolean;
   decorateRequest?: boolean;
   decorationPropertyName?: string;
+  isBinary?: (reply: FastifyReply) => boolean;
 }
 
 export interface LambdaResponse {

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ module.exports = (app, options) => {
         })
 
         const contentType = (res.headers['content-type'] || res.headers['Content-Type'] || '').split(';')[0]
-        const customBinaryCheck = typeof options.isBinary === 'function' && !!options.isBinary(res)
+        const customBinaryCheck = typeof options.isBinary === 'function' && options.isBinary(res)
         const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || customBinaryCheck
 
         const ret = {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,11 @@
+const isCompressed = (res) => {
+  const contentEncoding = res.headers['content-encoding']
+  return contentEncoding && contentEncoding !== 'identity'
+}
+
+const customBinaryCheck = (options, res) =>
+  typeof options.enforceBase64 === 'function' && options.enforceBase64(res) === true
+
 module.exports = (app, options) => {
   options = options || {}
   options.binaryMimeTypes = options.binaryMimeTypes || []
@@ -110,10 +118,7 @@ module.exports = (app, options) => {
         })
 
         const contentType = (res.headers['content-type'] || res.headers['Content-Type'] || '').split(';')[0]
-        const contentEncoding = res.headers['content-encoding'] || res.headers['Content-Encoding']
-        const isCompressed = contentEncoding && contentEncoding !== 'identity'
-        const customBinaryCheck = typeof options.enforceBase64 === 'function' && options.enforceBase64(res) === true
-        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || isCompressed || customBinaryCheck
+        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || isCompressed(res) || customBinaryCheck(options, res)
 
         const ret = {
           statusCode: res.statusCode,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const isCompressed = (res) => {
-  const contentEncoding = res.headers['content-encoding']
+  const contentEncoding = res.headers['content-encoding'] || res.headers['Content-Encoding']
   return contentEncoding && contentEncoding !== 'identity'
 }
 

--- a/index.js
+++ b/index.js
@@ -110,7 +110,8 @@ module.exports = (app, options) => {
         })
 
         const contentType = (res.headers['content-type'] || res.headers['Content-Type'] || '').split(';')[0]
-        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1
+        const contentEncoding = res.headers['content-encoding'] || res.headers['Content-Encoding'] || ''
+        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || !!contentEncoding
 
         const ret = {
           statusCode: res.statusCode,

--- a/index.js
+++ b/index.js
@@ -110,8 +110,10 @@ module.exports = (app, options) => {
         })
 
         const contentType = (res.headers['content-type'] || res.headers['Content-Type'] || '').split(';')[0]
-        const customBinaryCheck = typeof options.isBinary === 'function' && options.isBinary(res)
-        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || customBinaryCheck
+        const contentEncoding = res.headers['content-encoding'] || res.headers['Content-Encoding']
+        const isCompressed = contentEncoding && contentEncoding !== 'identity'
+        const customBinaryCheck = typeof options.enforceBase64 === 'function' && options.enforceBase64(res) === true
+        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || isCompressed || customBinaryCheck
 
         const ret = {
           statusCode: res.statusCode,

--- a/index.js
+++ b/index.js
@@ -110,8 +110,8 @@ module.exports = (app, options) => {
         })
 
         const contentType = (res.headers['content-type'] || res.headers['Content-Type'] || '').split(';')[0]
-        const contentEncoding = res.headers['content-encoding'] || res.headers['Content-Encoding'] || ''
-        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || !!contentEncoding
+        const customBinaryCheck = typeof options.isBinary === 'function' && !!options.isBinary(res)
+        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || customBinaryCheck
 
         const ret = {
           statusCode: res.statusCode,

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
-const isCompressed = (res) => {
+const isCompressedDefault = (res) => {
   const contentEncoding = res.headers['content-encoding'] || res.headers['Content-Encoding']
   return contentEncoding && contentEncoding !== 'identity'
 }
 
-const customBinaryCheck = (options, res) =>
-  typeof options.enforceBase64 === 'function' && options.enforceBase64(res) === true
+const customBinaryCheck = (options, res) => {
+  const enforceBase64 = typeof options.enforceBase64 === 'function' ? options.enforceBase64 : isCompressedDefault
+  return enforceBase64(res) === true
+}
 
 module.exports = (app, options) => {
   options = options || {}
@@ -118,7 +120,7 @@ module.exports = (app, options) => {
         })
 
         const contentType = (res.headers['content-type'] || res.headers['Content-Type'] || '').split(';')[0]
-        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || isCompressed(res) || customBinaryCheck(options, res)
+        const isBase64Encoded = options.binaryMimeTypes.indexOf(contentType) > -1 || customBinaryCheck(options, res)
 
         const ret = {
           statusCode: res.statusCode,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -70,7 +70,7 @@ expectAssignable<LambdaFastifyOptions>({
   serializeLambdaArguments: false,
   decorateRequest: true,
   decorationPropertyName: "myAWSstuff",
-  isBinary: (reply) => false,
+  enforceBase64: (reply) => false,
 });
 
 expectError(awsLambdaFastify());

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -64,6 +64,14 @@ expectAssignable<LambdaFastifyOptions>({
   decorateRequest: true,
   decorationPropertyName: "myAWSstuff",
 });
+expectAssignable<LambdaFastifyOptions>({
+  binaryMimeTypes: ["foo", "bar"],
+  callbackWaitsForEmptyEventLoop: true,
+  serializeLambdaArguments: false,
+  decorateRequest: true,
+  decorationPropertyName: "myAWSstuff",
+  isBinary: (reply) => false,
+});
 
 expectError(awsLambdaFastify());
 expectError(awsLambdaFastify(app, { neh: "definition" }));

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -81,8 +81,8 @@ test('GET with base64 encoding response', async (t) => {
   t.equal(ret.headers['set-cookie'], 'qwerty=one')
 })
 
-test('GET with custom binary check response', async (t) => {
-  t.plan(15)
+test('GET with content-encoding response', async (t) => {
+  t.plan(16)
 
   const readFileAsync = promisify(fs.readFile)
   const fileBuffer = await readFileAsync(__filename)
@@ -94,13 +94,51 @@ test('GET with custom binary check response', async (t) => {
     t.equal(request.headers.host, 'localhost:80')
     t.equal(request.headers['content-length'], '0')
     reply.header('Set-Cookie', 'qwerty=one')
-    reply.header('Content-Encoding', 'gzip')
+    reply.header('content-encoding', 'br')
+    reply.send(fileBuffer)
+  })
+  const proxy = awsLambdaFastify(app, { binaryMimeTypes: [], serializeLambdaArguments: true })
+  const ret = await proxy({
+    httpMethod: 'GET',
+    path: '/test',
+    headers: {
+      'X-My-Header': 'wuuusaaa',
+      'Content-Type': 'application/json'
+    }
+  })
+  t.equal(ret.statusCode, 200)
+  t.equal(ret.body, fileBuffer.toString('base64'))
+  t.equal(ret.isBase64Encoded, true)
+  t.ok(ret.headers)
+  t.equal(ret.headers['content-type'], 'application/octet-stream')
+  t.ok(ret.headers['content-length'])
+  t.ok(ret.headers.date)
+  t.equal(ret.headers.connection, 'keep-alive')
+  t.same(ret.multiValueHeaders, undefined)
+  t.equal(ret.headers['set-cookie'], 'qwerty=one')
+  t.equal(ret.headers['content-encoding'], 'br')
+})
+
+test('GET with custom binary check response', async (t) => {
+  t.plan(16)
+
+  const readFileAsync = promisify(fs.readFile)
+  const fileBuffer = await readFileAsync(__filename)
+  const app = fastify()
+  app.get('/test', async (request, reply) => {
+    t.equal(request.headers['x-my-header'], 'wuuusaaa')
+    t.equal(request.headers['x-apigateway-event'], '%7B%22httpMethod%22%3A%22GET%22%2C%22path%22%3A%22%2Ftest%22%2C%22headers%22%3A%7B%22X-My-Header%22%3A%22wuuusaaa%22%2C%22Content-Type%22%3A%22application%2Fjson%22%7D%7D')
+    t.equal(request.headers['user-agent'], 'lightMyRequest')
+    t.equal(request.headers.host, 'localhost:80')
+    t.equal(request.headers['content-length'], '0')
+    reply.header('Set-Cookie', 'qwerty=one')
+    reply.header('X-Base64-Encoded', '1')
     reply.send(fileBuffer)
   })
   const proxy = awsLambdaFastify(app, {
     binaryMimeTypes: [],
     serializeLambdaArguments: true,
-    isBinary: (res) => !!(res.headers['Content-Encoding'] || res.headers['content-encoding'])
+    enforceBase64: (reply) => reply.headers['x-base64-encoded'] === '1'
   })
   const ret = await proxy({
     httpMethod: 'GET',
@@ -120,6 +158,7 @@ test('GET with custom binary check response', async (t) => {
   t.equal(ret.headers.connection, 'keep-alive')
   t.same(ret.multiValueHeaders, undefined)
   t.equal(ret.headers['set-cookie'], 'qwerty=one')
+  t.equal(ret.headers['x-base64-encoded'], '1')
 })
 
 test('GET with multi-value query params', async (t) => {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -81,7 +81,7 @@ test('GET with base64 encoding response', async (t) => {
   t.equal(ret.headers['set-cookie'], 'qwerty=one')
 })
 
-test('GET with Content-Encoding response', async (t) => {
+test('GET with custom binary check response', async (t) => {
   t.plan(15)
 
   const readFileAsync = promisify(fs.readFile)
@@ -97,7 +97,11 @@ test('GET with Content-Encoding response', async (t) => {
     reply.header('Content-Encoding', 'gzip')
     reply.send(fileBuffer)
   })
-  const proxy = awsLambdaFastify(app, { binaryMimeTypes: [], serializeLambdaArguments: true })
+  const proxy = awsLambdaFastify(app, {
+    binaryMimeTypes: [],
+    serializeLambdaArguments: true,
+    isBinary: (res) => !!(res.headers['Content-Encoding'] || res.headers['content-encoding'])
+  })
   const ret = await proxy({
     httpMethod: 'GET',
     path: '/test',


### PR DESCRIPTION
Add support to use base64 encoding when the header `Content-Encoding` is set for compressed responses. See #117 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
 