### PR TITLE
fix: type in enforceBase64 callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm i @fastify/aws-lambda
 | property                       | description                                                                                                                          | default value |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
 | binaryMimeTypes                | Array of binary MimeTypes to handle                                                                                                  | `[]`          |
-| enforceBase64                  | Function that receives the reply and returns a boolean indicating if the response content is binary or not and should be base64-encoded                          | `undefined`   |
+| enforceBase64                  | Function that receives the response and returns a boolean indicating if the response content is binary or not and should be base64-encoded                          | `undefined`   |
 | serializeLambdaArguments       | Activate the serialization of lambda Event and Context in http header `x-apigateway-event` `x-apigateway-context`                    | `false` *(was `true` for <v2.0.0)*        |
 | decorateRequest       | Decorates the fastify request with the lambda Event and Context `request.awsLambda.event` `request.awsLambda.context`                    | `true`        |
 | decorationPropertyName       | The default property name for request decoration                    | `awsLambda`        |

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import { Context } from "aws-lambda";
-import { FastifyInstance, FastifyReply } from "fastify";
+import { FastifyInstance } from "fastify";
+import {Response as LightMyRequestResponse} from "light-my-request";
 
 export interface LambdaFastifyOptions {
   binaryMimeTypes?: string[];
@@ -7,7 +8,7 @@ export interface LambdaFastifyOptions {
   serializeLambdaArguments?: boolean;
   decorateRequest?: boolean;
   decorationPropertyName?: string;
-  enforceBase64?: (reply: FastifyReply) => boolean;
+  enforceBase64?: (response: LightMyRequestResponse) => boolean;
 }
 
 export interface LambdaResponse {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 import { Context } from "aws-lambda";
-import { FastifyInstance } from "fastify";
-import {Response as LightMyRequestResponse} from "light-my-request";
+import { FastifyInstance, LightMyRequestResponse } from "fastify";
 
 export interface LambdaFastifyOptions {
   binaryMimeTypes?: string[];

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import fastify from "fastify";
+import fastify, {LightMyRequestResponse} from "fastify";
 import awsLambdaFastify, {
   PromiseHandler,
   CallbackHandler,
@@ -70,7 +70,10 @@ expectAssignable<LambdaFastifyOptions>({
   serializeLambdaArguments: false,
   decorateRequest: true,
   decorationPropertyName: "myAWSstuff",
-  enforceBase64: (response) => false,
+  enforceBase64: (response) => {
+      expectType<LightMyRequestResponse>(response);
+      return false;
+  },
 });
 
 expectError(awsLambdaFastify());

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -70,7 +70,7 @@ expectAssignable<LambdaFastifyOptions>({
   serializeLambdaArguments: false,
   decorateRequest: true,
   decorationPropertyName: "myAWSstuff",
-  enforceBase64: (reply) => false,
+  enforceBase64: (response) => false,
 });
 
 expectError(awsLambdaFastify());

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "aws-serverless-fastify": "^1.0.28",
     "benchmark": "^2.1.4",
     "eslint": "^8.17.0",
+    "light-my-request": "^5.0.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.2.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "aws-serverless-fastify": "^1.0.28",
     "benchmark": "^2.1.4",
     "eslint": "^8.17.0",
-    "light-my-request": "^5.0.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.2.1",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -138,7 +138,7 @@ test('GET with custom binary check response', async (t) => {
   const proxy = awsLambdaFastify(app, {
     binaryMimeTypes: [],
     serializeLambdaArguments: true,
-    enforceBase64: (reply) => reply.headers['x-base64-encoded'] === '1'
+    enforceBase64: (response) => response.headers['x-base64-encoded'] === '1'
   })
   const ret = await proxy({
     httpMethod: 'GET',


### PR DESCRIPTION
The type in the `enforceBase64` callable is not of `FastifyReply` type but `Response` from `light-my-request` package.
I changed code to note that the parameter is a `response`, not a `reply`.
Also changed `reply` to `response` in the explanation of the `enforceBase64` parameter in the docs.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
