### PR TITLE
test: add in middy comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   "devDependencies": {
     "@fastify/multipart": "7.6.0",
     "@fastify/pre-commit": "^2.0.2",
+    "@middy/core": "^4.4.2",
+    "@middy/http-router": "^4.4.2",
     "@types/aws-lambda": "8.10.115",
     "aws-lambda": "^1.0.7",
     "aws-serverless-express": "^3.4.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

I had a few from your community reach out asking how `middy` compared to `@fastify/aws-lambda` performance wise. So here is the results:

```bash
aws-serverless-express x 14,483 ops/sec ±0.71% (89 runs sampled)
aws-serverless-fastify x 13,799 ops/sec ±2.76% (78 runs sampled)
@middy/core x 1,332,142 ops/sec ±5.58% (63 runs sampled)
@middy/core + @middy/http-router x 1,372,619 ops/sec ±5.24% (71 runs sampled)
serverless-http x 40,785 ops/sec ±3.15% (86 runs sampled)
aws-lambda-fastify x 52,456 ops/sec ±2.59% (83 runs sampled)
aws-lambda-fastify (serializeLambdaArguments : true) x 52,963 ops/sec ±1.87% (87 runs sampled)
aws-lambda-fastify (decorateRequest : false) x 51,735 ops/sec ±2.73% (84 runs sampled)
Fastest is @middy/core + @middy/http-router,@middy/core
```

- `@middy/core`: Shows when the pattern when there is one lambda per endpoint, router not needed
- `@middy/core + @middy/http-router`: Show when a more monolith approach is preferred. This is equivalent to `@fastify/aws-lambda (decorateRequest : false)` based on my understanding of your docs.

Please let me know if there are any changes you need to make the comparison more accurate.

#### Checklist

- [x] run `npm run test` and `npm run performance`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
