### PR TITLE
Add option to retain the API Gateway stage in the URL passed to fastify

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ $ npm i @fastify/aws-lambda
 
 **@fastify/aws-lambda** can take options by passing them with : `awsLambdaFastify(app, options)`
 
-| property                       | description                                                                                                                          | default value |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| binaryMimeTypes                | Array of binary MimeTypes to handle                                                                                                  | `[]`          |
-| enforceBase64                  | Function that receives the response and returns a boolean indicating if the response content is binary or not and should be base64-encoded                          | `undefined`   |
-| serializeLambdaArguments       | Activate the serialization of lambda Event and Context in http header `x-apigateway-event` `x-apigateway-context`                    | `false` *(was `true` for <v2.0.0)*        |
-| decorateRequest       | Decorates the fastify request with the lambda Event and Context `request.awsLambda.event` `request.awsLambda.context`                    | `true`        |
-| decorationPropertyName       | The default property name for request decoration                    | `awsLambda`        |
-| callbackWaitsForEmptyEventLoop | See: [Official Documentation](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html#nodejs-prog-model-context-properties) | `undefined`   |
+| property                       | description                                                                                                                                | default value                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
+| binaryMimeTypes                | Array of binary MimeTypes to handle                                                                                                        | `[]`                               |
+| enforceBase64                  | Function that receives the response and returns a boolean indicating if the response content is binary or not and should be base64-encoded | `undefined`                        |
+| serializeLambdaArguments       | Activate the serialization of lambda Event and Context in http header `x-apigateway-event` `x-apigateway-context`                          | `false` *(was `true` for <v2.0.0)* |
+| decorateRequest                | Decorates the fastify request with the lambda Event and Context `request.awsLambda.event` `request.awsLambda.context`                      | `true`                             |
+| decorationPropertyName         | The default property name for request decoration                                                                                           | `awsLambda`                        |
+| callbackWaitsForEmptyEventLoop | See: [Official Documentation](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html#nodejs-prog-model-context-properties)       | `undefined`                        |
+| retainStage                    | Retain the stage part of the API Gateway URL                                                                                               | `false`                            |
 
 ## 📖Example
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = (app, options) => {
   options.binaryMimeTypes = options.binaryMimeTypes || []
   options.serializeLambdaArguments = options.serializeLambdaArguments !== undefined ? options.serializeLambdaArguments : false
   options.decorateRequest = options.decorateRequest !== undefined ? options.decorateRequest : true
+  options.retainStage = options.retainStage !== undefined ? options.retainStage : false
   let currentAwsArguments = {}
   if (options.decorateRequest) {
     options.decorationPropertyName = options.decorationPropertyName || 'awsLambda'
@@ -40,8 +41,8 @@ module.exports = (app, options) => {
     const method = event.httpMethod || (event.requestContext && event.requestContext.http ? event.requestContext.http.method : undefined)
     let url = event.path || event.rawPath || '/' // seen rawPath for HTTP-API
     // NOTE: if used directly via API Gateway domain and /stage
-    if (event.requestContext && event.requestContext.stage && event.requestContext.resourcePath &&
-        (url).indexOf(`/${event.requestContext.stage}/`) === 0 &&
+    if (!options.retainStage && event.requestContext && event.requestContext.stage && 
+        event.requestContext.resourcePath && (url).indexOf(`/${event.requestContext.stage}/`) === 0 &&
         event.requestContext.resourcePath.indexOf(`/${event.requestContext.stage}/`) !== 0) {
       url = url.substring(event.requestContext.stage.length + 1)
     }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = (app, options) => {
     const method = event.httpMethod || (event.requestContext && event.requestContext.http ? event.requestContext.http.method : undefined)
     let url = event.path || event.rawPath || '/' // seen rawPath for HTTP-API
     // NOTE: if used directly via API Gateway domain and /stage
-    if (!options.retainStage && event.requestContext && event.requestContext.stage && 
+    if (!options.retainStage && event.requestContext && event.requestContext.stage &&
         event.requestContext.resourcePath && (url).indexOf(`/${event.requestContext.stage}/`) === 0 &&
         event.requestContext.resourcePath.indexOf(`/${event.requestContext.stage}/`) !== 0) {
       url = url.substring(event.requestContext.stage.length + 1)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,7 @@ declare namespace awsLambdaFastify {
     decorateRequest?: boolean;
     decorationPropertyName?: string;
     enforceBase64?: (response: LightMyRequestResponse) => boolean;
+    retainStage?: boolean;
   }
   
   export interface LambdaResponse {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -75,6 +75,18 @@ expectAssignable<LambdaFastifyOptions>({
       return false;
   },
 });
+expectAssignable<LambdaFastifyOptions>({
+  binaryMimeTypes: ["foo", "bar"],
+  callbackWaitsForEmptyEventLoop: true,
+  serializeLambdaArguments: false,
+  decorateRequest: true,
+  decorationPropertyName: "myAWSstuff",
+  enforceBase64: (response) => {
+      expectType<LightMyRequestResponse>(response);
+      return false;
+  },
+  retainStage: true,
+});
 
 expectError(awsLambdaFastify());
 expectError(awsLambdaFastify(app, { neh: "definition" }));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

On my team we have an API Gateway with a stage that we want to include in the URL passed to fastify. E.g. we have the stage `stage` with a resource `my-resource`, we would have this route in fastify:

```
app.get("/stage/my-resource", ...);
```

Currently the "stage" part is stripped from the URL:

```
    let url = event.path || event.rawPath || '/' // seen rawPath for HTTP-API
    // NOTE: if used directly via API Gateway domain and /stage
    if (event.requestContext && event.requestContext.stage && event.requestContext.resourcePath &&
        (url).indexOf(`/${event.requestContext.stage}/`) === 0 &&
        event.requestContext.resourcePath.indexOf(`/${event.requestContext.stage}/`) !== 0) {
      url = url.substring(event.requestContext.stage.length + 1)
    }
```

This PR adds a new option called `retainStage` that will make sure to retain the stage part of the URL.

**This extends the public API!** I have documented the change in README.md and updated the TS definition. The change is non-breaking.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

```
npm run test

...
Suites:   ​3 passed​, ​3 of 3 completed​
Asserts:  ​​​222 passed​, ​of 222​
```

```
npm run performance

aws-serverless-express x 10,951 ops/sec ±11.14% (75 runs sampled)
(node:31068) [FSTDEP011] FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.
(Use `node --trace-warnings ...` to show where the warning was created)
aws-serverless-fastify x 15,076 ops/sec ±2.88% (89 runs sampled)
serverless-http x 32,611 ops/sec ±6.82% (83 runs sampled)
aws-lambda-fastify x 43,800 ops/sec ±2.82% (81 runs sampled)
aws-lambda-fastify (serializeLambdaArguments : true) x 44,551 ops/sec ±1.99% (85 runs sampled)
aws-lambda-fastify (decorateRequest : false) x 43,636 ops/sec ±3.34% (81 runs sampled)
Fastest is aws-lambda-fastify (serializeLambdaArguments : true),aws-lambda-fastify,aws-lambda-fastify (decorateRequest : false)
```
