### PR TITLE
docs(serverless-adapter): add another lib to benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@fastify/multipart": "8.1.0",
     "@fastify/pre-commit": "^2.1.0",
+    "@h4ad/serverless-adapter": "4.2.0",
     "@types/aws-lambda": "8.10.132",
     "aws-lambda": "^1.0.7",
     "aws-serverless-express": "^3.4.0",


### PR DESCRIPTION
Adding my [serverless-adapter](https://github.com/H4ad/serverless-adapter) lib to benchmark section.

Results:

```
aws-serverless-express x 12,355 ops/sec ±0.97% (85 runs sampled)
aws-serverless-fastify x 15,357 ops/sec ±0.70% (83 runs sampled)
serverless-http x 25,177 ops/sec ±2.07% (83 runs sampled)
@h4ad/serverless-adapter x 100,646 ops/sec ±0.82% (87 runs sampled)
aws-lambda-fastify x 35,063 ops/sec ±2.49% (80 runs sampled)
aws-lambda-fastify (serializeLambdaArguments : true) x 36,647 ops/sec ±0.87% (85 runs sampled)
aws-lambda-fastify (decorateRequest : false) x 36,463 ops/sec ±1.01% (85 runs sampled)
Fastest is @h4ad/serverless-adapter
```

I slightly modified the `event` object to include properties that exist on the payload that my library expect and use.

#### Checklist

- [x] run `npm run test` and `npm run performance`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
