### PR TITLE
Allow users to opt out of literal comma "," query parameters parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ npm i @fastify/aws-lambda
 | callbackWaitsForEmptyEventLoop | See: [Official Documentation](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html#nodejs-prog-model-context-properties)       | `undefined`                        |
 | retainStage                    | Retain the stage part of the API Gateway URL                                                                                               | `false`                            |
 | pathParameterUsedAsPath        | Use a defined pathParameter as path (i.e. `'proxy'`)                                                                                               | `false`                            |
-
+| parseCommaSeparatedQueryParams        | Parse querystring with commas into an array of values. Affects the behavior of the querystring parser with commas while using [Payload Format Version 2.0](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format)                                                                                               | `true`                            |
 ## 📖Example
 
 ### lambda.js

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,6 +16,16 @@ declare namespace awsLambdaFastify {
      * usually set to 'proxy', if used
      */
     pathParameterUsedAsPath?: string;
+    /**
+     * Parse querystring with commas into an array of values.
+     * Affects the behavior of the querystring parser with commas while using [Payload Format Version 2.0](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format)
+     * 
+     * e.g. when set to `true` (default) `?foo=qux,bar` => `{ foo: ['qux', 'bar'] }`
+     * 
+     * e.g. when set to `false` `?foo=qux,bar` => `{ foo: 'qux,bar' }`
+     * @default true
+     */
+    parseCommaSeparatedQueryParams?: boolean;
   }
   
   export interface LambdaResponse {


### PR DESCRIPTION
Fixes #202 by adding a new optional option `parseCommaSeparatedQueryParams` to opt-out from parsing multi-value query params with api gateway v2.0 format.

Additionally fixes a bug where the lambda incoming `event` argument was manipulated during the parsing. This may cause confusion for users attempting to log the original lambda argument when using `request.awsLambda.event.queryStringParameters`


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
